### PR TITLE
Add marketing pages referenced in footer

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -10,6 +10,13 @@ import GDPRPasswordCompliance from "@/pages/gdpr-password-compliance";
 import ISO27001PasswordRules from "@/pages/iso27001-password-rules";
 import PCIDSSPasswordRequirements from "@/pages/pci-dss-password-requirements";
 import ComplianceComparison from "@/pages/compliance-comparison";
+import PasswordBestPractices from "@/pages/password-best-practices";
+import ComplianceGuides from "@/pages/compliance-guides";
+import SecurityBlog from "@/pages/security-blog";
+import HowItWorks from "@/pages/how-it-works";
+import PrivacyPolicy from "@/pages/privacy-policy";
+import TermsOfService from "@/pages/terms-of-service";
+import Contact from "@/pages/contact";
 
 function Router() {
   return (
@@ -20,6 +27,13 @@ function Router() {
       <Route path="/iso27001-password-rules" component={ISO27001PasswordRules} />
       <Route path="/pci-dss-password-requirements" component={PCIDSSPasswordRequirements} />
       <Route path="/compliance-comparison" component={ComplianceComparison} />
+      <Route path="/password-best-practices" component={PasswordBestPractices} />
+      <Route path="/compliance-guides" component={ComplianceGuides} />
+      <Route path="/security-blog" component={SecurityBlog} />
+      <Route path="/how-it-works" component={HowItWorks} />
+      <Route path="/privacy-policy" component={PrivacyPolicy} />
+      <Route path="/terms-of-service" component={TermsOfService} />
+      <Route path="/contact" component={Contact} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/pages/compliance-guides.tsx
+++ b/client/src/pages/compliance-guides.tsx
@@ -1,0 +1,176 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, BookOpen, Layers, Target, ClipboardCheck, Clock3 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function ComplianceGuides() {
+  useEffect(() => {
+    document.title = 'Password Compliance Guides | SecureCheck';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Step-by-step password compliance guides for NIST, GDPR, ISO 27001, and PCI DSS. Understand scope, stakeholders, and controls required for certification.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'Password Compliance Guides | SecureCheck');
+    addMetaTag(
+      'og:description',
+      'Implementation checklists and practical advice for aligning password policies with leading security regulations.'
+    );
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const guides = [
+    {
+      name: 'NIST SP 800-63B',
+      focus: 'Federal and public sector identity assurance',
+      steps: [
+        'Adopt memorized secret rules without unnecessary complexity requirements.',
+        'Implement breach password screening against current compromised datasets.',
+        'Provide secure recovery options and restrict knowledge-based questions.'
+      ]
+    },
+    {
+      name: 'GDPR',
+      focus: 'Data protection across the European Union',
+      steps: [
+        'Map personal data flows and classify authentication risk for each system.',
+        'Document technical and organisational measures supporting strong authentication.',
+        'Demonstrate regular reviews, staff training, and incident response alignment.'
+      ]
+    },
+    {
+      name: 'ISO 27001',
+      focus: 'Enterprise information security management',
+      steps: [
+        'Align password policies with Annex A control set and risk assessments.',
+        'Integrate SecureCheck reports into management review evidence.',
+        'Track corrective actions for weak passwords found during internal audits.'
+      ]
+    },
+    {
+      name: 'PCI DSS v4.0',
+      focus: 'Payment card industry data environments',
+      steps: [
+        'Ensure passwords meet minimum length and alphanumeric requirements.',
+        'Enforce multi-factor authentication for all access into the CDE.',
+        'Log password policy changes and review them during quarterly security scans.'
+      ]
+    }
+  ];
+
+  const programmePhases = [
+    {
+      title: 'Scope & Inventory',
+      description: 'Identify systems, privileged accounts, and third-party services that fall under your compliance boundary.',
+      icon: Layers
+    },
+    {
+      title: 'Control Implementation',
+      description: 'Apply technical safeguards, deploy SecureCheck for validation, and train staff on new password expectations.',
+      icon: ClipboardCheck
+    },
+    {
+      title: 'Continuous Monitoring',
+      description: 'Track compliance drift, monitor breach feeds, and keep documentation ready for auditors year-round.',
+      icon: Clock3
+    }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-purple-100 dark:from-gray-900 dark:to-purple-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-purple-600 dark:text-purple-400">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-purple-100 dark:bg-purple-900 rounded-full">
+              <BookOpen className="h-12 w-12 text-purple-600 dark:text-purple-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">Compliance Guides</h1>
+          <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            Navigate certification requirements with practical, plain-language guidance. Each guide highlights the password
+            controls auditors expect and how SecureCheck keeps evidence current.
+          </p>
+        </div>
+
+        <section className="mb-16">
+          <div className="grid gap-6 md:grid-cols-2">
+            {guides.map((guide) => (
+              <Card key={guide.name} className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+                <CardHeader>
+                  <CardTitle className="text-xl">{guide.name}</CardTitle>
+                  <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                    {guide.focus}
+                  </CardDescription>
+                </CardHeader>
+                <CardContent>
+                  <ul className="space-y-3 text-gray-600 dark:text-gray-300">
+                    {guide.steps.map((step) => (
+                      <li key={step} className="flex items-start">
+                        <Target className="h-5 w-5 text-purple-500 mt-1 mr-3" />
+                        <span>{step}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-8 text-center">Programme Roadmap</h2>
+          <div className="grid md:grid-cols-3 gap-8">
+            {programmePhases.map((phase) => {
+              const Icon = phase.icon;
+              return (
+                <div key={phase.title} className="text-center space-y-4">
+                  <div className="flex justify-center">
+                    <div className="p-3 rounded-full bg-purple-100 dark:bg-purple-900">
+                      <Icon className="h-8 w-8 text-purple-600 dark:text-purple-400" />
+                    </div>
+                  </div>
+                  <h3 className="text-xl font-semibold text-gray-900 dark:text-white">{phase.title}</h3>
+                  <p className="text-gray-600 dark:text-gray-300">{phase.description}</p>
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -1,0 +1,174 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, Mail, PhoneCall, MessageSquare, MapPin, Send } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Input } from '@/components/ui/input';
+
+export default function Contact() {
+  useEffect(() => {
+    document.title = 'Contact SecureCheck';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Contact the SecureCheck team for support, partnerships, or compliance questions. We respond within two business days.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'Contact SecureCheck');
+    addMetaTag('og:description', 'Reach the SecureCheck team for product support, enterprise onboarding, or media enquiries.');
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const contactMethods = [
+    {
+      title: 'Email',
+      description: 'General support and enterprise onboarding questions. Expect a response within two business days.',
+      icon: Mail,
+      value: 'hello@securecheck.app',
+      href: 'mailto:hello@securecheck.app'
+    },
+    {
+      title: 'Phone',
+      description: 'For urgent security notifications. Please leave a voicemail with contact details.',
+      icon: PhoneCall,
+      value: '+1 (555) 123-4567',
+      href: 'tel:+15551234567'
+    },
+    {
+      title: 'Community',
+      description: 'Join the SecureCheck community chat to share feedback and request new features.',
+      icon: MessageSquare,
+      value: 'community.securecheck.app',
+      href: 'https://community.securecheck.app'
+    }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-sky-50 to-indigo-100 dark:from-slate-900 dark:to-indigo-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-indigo-600 dark:text-indigo-400">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-indigo-100 dark:bg-indigo-900 rounded-full">
+              <Send className="h-12 w-12 text-indigo-600 dark:text-indigo-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">Contact SecureCheck</h1>
+          <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            We are here to help with onboarding, compliance questions, and partnership opportunities. Choose the channel that
+            suits you best.
+          </p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <Card className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+            <CardHeader>
+              <CardTitle className="text-2xl">Message the Team</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <form className="space-y-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" htmlFor="name">
+                    Name
+                  </label>
+                  <Input id="name" placeholder="Your name" required />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" htmlFor="email">
+                    Email
+                  </label>
+                  <Input id="email" type="email" placeholder="you@example.com" required />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 dark:text-gray-200 mb-1" htmlFor="message">
+                    Message
+                  </label>
+                  <Textarea id="message" placeholder="How can we help?" rows={4} required />
+                </div>
+                <Button type="submit" className="bg-indigo-600 hover:bg-indigo-700 text-white w-full">
+                  Send message
+                </Button>
+                <p className="text-xs text-muted-foreground">
+                  We do not store submitted messages in this demo environment. For production enquiries, please email us directly.
+                </p>
+              </form>
+            </CardContent>
+          </Card>
+
+          <div className="space-y-6">
+            {contactMethods.map((method) => {
+              const Icon = method.icon;
+              return (
+                <Card key={method.title} className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+                  <CardHeader className="flex flex-row items-start space-x-3">
+                    <div className="p-3 rounded-full bg-indigo-100 dark:bg-indigo-900">
+                      <Icon className="h-6 w-6 text-indigo-600 dark:text-indigo-400" />
+                    </div>
+                    <div>
+                      <CardTitle className="text-xl">{method.title}</CardTitle>
+                      <div className="mt-3 text-gray-600 dark:text-gray-300 space-y-2">
+                        <p>{method.description}</p>
+                        <a href={method.href} className="text-indigo-600 dark:text-indigo-400 font-semibold">
+                          {method.value}
+                        </a>
+                      </div>
+                    </div>
+                  </CardHeader>
+                </Card>
+              );
+            })}
+
+            <Card className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+              <CardHeader className="flex items-start space-x-3">
+                <div className="p-3 rounded-full bg-indigo-100 dark:bg-indigo-900">
+                  <MapPin className="h-6 w-6 text-indigo-600 dark:text-indigo-400" />
+                </div>
+                <div>
+                  <CardTitle className="text-xl">Registered Office</CardTitle>
+                  <div className="mt-3 text-gray-600 dark:text-gray-300 space-y-1">
+                    <p>SecureCheck Ltd.</p>
+                    <p>221B Password Lane</p>
+                    <p>London, UK</p>
+                  </div>
+                </div>
+              </CardHeader>
+            </Card>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -125,9 +125,21 @@ export default function Home() {
               <h3 className="font-semibold mb-3">Resources</h3>
               <ul className="space-y-2 text-sm text-muted-foreground">
                 <li><Link href="/compliance-comparison" className="hover:text-foreground" data-testid="link-comparison">Standards Comparison</Link></li>
-                <li><a href="#" className="hover:text-foreground">Password Best Practices</a></li>
-                <li><a href="#" className="hover:text-foreground">Compliance Guides</a></li>
-                <li><a href="#" className="hover:text-foreground">Security Blog</a></li>
+                <li>
+                  <Link href="/password-best-practices" className="hover:text-foreground" data-testid="link-best-practices">
+                    Password Best Practices
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/compliance-guides" className="hover:text-foreground" data-testid="link-guides">
+                    Compliance Guides
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/security-blog" className="hover:text-foreground" data-testid="link-blog">
+                    Security Blog
+                  </Link>
+                </li>
               </ul>
             </div>
             
@@ -144,10 +156,26 @@ export default function Home() {
             <div>
               <h3 className="font-semibold mb-3">About</h3>
               <ul className="space-y-2 text-sm text-muted-foreground">
-                <li><a href="#" className="hover:text-foreground">How It Works</a></li>
-                <li><a href="#" className="hover:text-foreground">Privacy Policy</a></li>
-                <li><a href="#" className="hover:text-foreground">Terms of Service</a></li>
-                <li><a href="#" className="hover:text-foreground">Contact</a></li>
+                <li>
+                  <Link href="/how-it-works" className="hover:text-foreground" data-testid="link-how-it-works">
+                    How It Works
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/privacy-policy" className="hover:text-foreground" data-testid="link-privacy">
+                    Privacy Policy
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/terms-of-service" className="hover:text-foreground" data-testid="link-terms">
+                    Terms of Service
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/contact" className="hover:text-foreground" data-testid="link-contact">
+                    Contact
+                  </Link>
+                </li>
               </ul>
             </div>
           </div>

--- a/client/src/pages/how-it-works.tsx
+++ b/client/src/pages/how-it-works.tsx
@@ -1,0 +1,193 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, Workflow, Lock, Gauge, ScrollText, Users, ArrowRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export default function HowItWorks() {
+  useEffect(() => {
+    document.title = 'How SecureCheck Works | Password Analysis Workflow';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Understand SecureCheck\'s privacy-first password analysis workflow, scoring methodology, and compliance-ready reporting.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'How SecureCheck Works | Password Analysis Workflow');
+    addMetaTag('og:description', 'Explore our privacy-first architecture and compliance scoring pipeline.');
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const stages = [
+    {
+      title: 'Client-side Evaluation',
+      description: 'All password checks run locally in the browser. Nothing is transmitted or stored on SecureCheck servers.',
+      icon: Lock
+    },
+    {
+      title: 'Policy-aware Scoring',
+      description: 'Our scoring engine compares each password against the requirements of multiple compliance frameworks.',
+      icon: Gauge
+    },
+    {
+      title: 'Actionable Reporting',
+      description: 'Generate human-readable insights and export policy evidence for audits or executive updates.',
+      icon: ScrollText
+    }
+  ];
+
+  const trustSignals = [
+    'Open-source components with transparent change history.',
+    'No tracking scripts or analytics pixels in the application.',
+    'Regularly refreshed breach corpora to detect compromised credentials.',
+    'Extensible rules engine for custom organisational policies.'
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-cyan-100 dark:from-slate-900 dark:to-cyan-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-cyan-600 dark:text-cyan-400">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-cyan-100 dark:bg-cyan-900 rounded-full">
+              <Workflow className="h-12 w-12 text-cyan-600 dark:text-cyan-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">How SecureCheck Works</h1>
+          <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            SecureCheck combines client-side privacy, up-to-date compliance logic, and intuitive reporting. Learn how the tool
+            guides teams from password capture to audit-ready documentation in seconds.
+          </p>
+        </div>
+
+        <section className="mb-16">
+          <div className="grid gap-6 md:grid-cols-3">
+            {stages.map((stage) => {
+              const Icon = stage.icon;
+              return (
+                <Card key={stage.title} className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+                  <CardHeader className="text-center">
+                    <div className="flex justify-center mb-4">
+                      <div className="p-3 rounded-full bg-cyan-100 dark:bg-cyan-900">
+                        <Icon className="h-8 w-8 text-cyan-600 dark:text-cyan-400" />
+                      </div>
+                    </div>
+                    <CardTitle>{stage.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                      {stage.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8 mb-16">
+          <div className="grid md:grid-cols-2 gap-8 items-center">
+            <div>
+              <h2 className="text-3xl font-semibold text-gray-900 dark:text-white mb-4">Privacy-first Architecture</h2>
+              <p className="text-gray-600 dark:text-gray-300 mb-6">
+                Your credentials never leave the device. SecureCheck leverages modern browser APIs, Web Crypto, and optimised
+                datasets to evaluate password strength and compliance locally without risking leakage.
+              </p>
+              <Link href="/">
+                <Button className="bg-cyan-600 hover:bg-cyan-700 text-white">
+                  Try SecureCheck Now
+                  <ArrowRight className="h-4 w-4 ml-2" />
+                </Button>
+              </Link>
+            </div>
+            <div className="space-y-4 text-gray-600 dark:text-gray-300">
+              {trustSignals.map((item) => (
+                <div key={item} className="flex items-start">
+                  <span className="mt-1 mr-3 inline-flex h-2 w-2 rounded-full bg-cyan-500" aria-hidden />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-white/80 dark:bg-gray-900/80 rounded-2xl shadow-lg p-8">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-6 text-center">Collaboration Workflow</h2>
+          <div className="grid md:grid-cols-3 gap-6">
+            <Card className="border border-cyan-100 dark:border-cyan-900 bg-white dark:bg-gray-900">
+              <CardHeader>
+                <CardTitle className="flex items-center text-lg">
+                  <Users className="h-5 w-5 text-cyan-500 mr-2" />
+                  Share Findings
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                  Export compliance summaries or copy remediation steps directly into your ticketing system.
+                </CardDescription>
+              </CardContent>
+            </Card>
+            <Card className="border border-cyan-100 dark:border-cyan-900 bg-white dark:bg-gray-900">
+              <CardHeader>
+                <CardTitle className="flex items-center text-lg">
+                  <Gauge className="h-5 w-5 text-cyan-500 mr-2" />
+                  Track Progress
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                  Monitor improvements with compliance scores and highlight the most impactful policy updates.
+                </CardDescription>
+              </CardContent>
+            </Card>
+            <Card className="border border-cyan-100 dark:border-cyan-900 bg-white dark:bg-gray-900">
+              <CardHeader>
+                <CardTitle className="flex items-center text-lg">
+                  <ScrollText className="h-5 w-5 text-cyan-500 mr-2" />
+                  Evidence for Audits
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                  Produce reports that map findings back to policy clauses and regulatory citations in minutes.
+                </CardDescription>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/password-best-practices.tsx
+++ b/client/src/pages/password-best-practices.tsx
@@ -1,0 +1,193 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, CheckCircle, ListChecks, Lock, AlertTriangle, Sparkles } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function PasswordBestPractices() {
+  useEffect(() => {
+    document.title = 'Password Best Practices Guide | SecureCheck';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Actionable password best practices for teams and individuals. Learn how to create secure passphrases, avoid common mistakes, and align with leading compliance standards.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'Password Best Practices Guide | SecureCheck');
+    addMetaTag(
+      'og:description',
+      'Practical password best practices that help your organisation stay compliant while protecting accounts from takeover.'
+    );
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const fundamentals = [
+    {
+      title: 'Think in Passphrases',
+      description: 'Use four or more unrelated words to create memorable and resilient passphrases of 16+ characters.',
+      icon: Sparkles
+    },
+    {
+      title: 'Unique Per System',
+      description: 'Never reuse passwords. Each system should have its own credential protected by MFA where possible.',
+      icon: CheckCircle
+    },
+    {
+      title: 'Password Managers',
+      description: 'Adopt a vetted password manager to generate, store, and share credentials securely across teams.',
+      icon: Lock
+    }
+  ];
+
+  const pitfalls = [
+    'Using predictable substitutions like "P@ssw0rd" that attackers anticipate.',
+    'Sharing credentials over email, chat, or tickets without encryption.',
+    'Ignoring breach notifications that indicate exposed passwords.',
+    'Keeping legacy systems on outdated complexity policies that harm usability.'
+  ];
+
+  const quickChecklist = [
+    'Length ≥ 14 characters (or policy-defined passphrase minimums).',
+    'Enabled MFA wherever available.',
+    'Password manager roll-out plan communicated to staff.',
+    'Quarterly review of breached password reports.',
+    'Documented recovery process without insecure reset questions.'
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-100 dark:from-slate-900 dark:to-blue-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-blue-100 dark:bg-blue-900 rounded-full">
+              <ListChecks className="h-12 w-12 text-blue-600 dark:text-blue-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">
+            Password Best Practices
+          </h1>
+          <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            Build a password culture that balances user experience with measurable security. These recommendations align with
+            NIST, ISO 27001, and PCI DSS guidance without resorting to outdated complexity rules.
+          </p>
+        </div>
+
+        <section className="mb-16">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-8 text-center">Core Fundamentals</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {fundamentals.map((item) => {
+              const Icon = item.icon;
+              return (
+                <Card key={item.title} className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+                  <CardHeader className="text-center">
+                    <div className="flex justify-center mb-4">
+                      <div className="p-3 rounded-full bg-blue-100 dark:bg-blue-900">
+                        <Icon className="h-8 w-8 text-blue-600 dark:text-blue-400" />
+                      </div>
+                    </div>
+                    <CardTitle>{item.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                      {item.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="mb-16">
+          <div className="grid md:grid-cols-2 gap-8">
+            <Card className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+              <CardHeader>
+                <CardTitle className="flex items-center text-lg">
+                  <CheckCircle className="h-5 w-5 text-green-500 mr-2" />
+                  Quick Readiness Checklist
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3 text-gray-600 dark:text-gray-300">
+                  {quickChecklist.map((item) => (
+                    <li key={item} className="flex items-start">
+                      <span className="mt-1 mr-2 inline-flex h-2 w-2 rounded-full bg-green-500" aria-hidden />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+
+            <Card className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80">
+              <CardHeader>
+                <CardTitle className="flex items-center text-lg">
+                  <AlertTriangle className="h-5 w-5 text-amber-500 mr-2" />
+                  Common Pitfalls to Avoid
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <ul className="space-y-3 text-gray-600 dark:text-gray-300">
+                  {pitfalls.map((item) => (
+                    <li key={item} className="flex items-start">
+                      <span className="mt-1 mr-2 inline-flex h-2 w-2 rounded-full bg-amber-500" aria-hidden />
+                      <span>{item}</span>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          </div>
+        </section>
+
+        <section className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-6">Roll-out Tips for Security Teams</h2>
+          <div className="space-y-4 text-gray-600 dark:text-gray-300">
+            <p>
+              Combine automated password auditing with a human-first enablement programme. Start with short sessions that explain
+              why composition rules are outdated, then give staff a template for building passphrases that meet compliance
+              expectations.
+            </p>
+            <p>
+              Reinforce adoption by measuring password reuse rates and triggering friendly nudges before compliance audits. Pair
+              SecureCheck&apos;s analysis with automated breach monitoring so high-risk passwords are rotated quickly without the
+              fatigue of scheduled resets.
+            </p>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/privacy-policy.tsx
+++ b/client/src/pages/privacy-policy.tsx
@@ -1,0 +1,129 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, LockKeyhole, EyeOff, Server, FileCheck2 } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export default function PrivacyPolicy() {
+  useEffect(() => {
+    document.title = 'SecureCheck Privacy Policy';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Learn how SecureCheck protects your privacy. All password analysis runs locally, with no tracking, logging, or data storage.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'SecureCheck Privacy Policy');
+    addMetaTag('og:description', 'Your passwords never leave the browser. Read our commitment to privacy, transparency, and compliance.');
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const sections = [
+    {
+      title: 'No Credential Collection',
+      icon: LockKeyhole,
+      content:
+        'Passwords you analyse with SecureCheck are processed entirely within your browser session. We do not transmit, capture, or store any credential data.'
+    },
+    {
+      title: 'Zero Third-party Trackers',
+      icon: EyeOff,
+      content:
+        'We avoid analytics pixels, cookies, or advertising scripts. Usage is anonymous and no personal data is collected for marketing purposes.'
+    },
+    {
+      title: 'Transparent Infrastructure',
+      icon: Server,
+      content:
+        'SecureCheck is a static web application. Our servers deliver the code, and the rest of the experience—including compliance checks—runs locally.'
+    },
+    {
+      title: 'Audit-ready Documentation',
+      icon: FileCheck2,
+      content:
+        'Need evidence for an internal privacy assessment? Export this policy along with SecureCheck reports to demonstrate compliance with privacy principles.'
+    }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-emerald-100 dark:from-slate-900 dark:to-emerald-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-emerald-600 dark:text-emerald-400">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-emerald-100 dark:bg-emerald-900 rounded-full">
+              <Shield className="h-12 w-12 text-emerald-600 dark:text-emerald-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">Privacy Policy</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            SecureCheck is designed to be privacy-first from day one. This policy explains the minimal data we handle, how we
+            protect it, and the choices you have when using the service.
+          </p>
+        </div>
+
+        <div className="space-y-10">
+          {sections.map((section) => {
+            const Icon = section.icon;
+            return (
+              <section key={section.title} className="bg-white/90 dark:bg-gray-900/80 rounded-2xl shadow-lg p-8">
+                <div className="flex items-start">
+                  <div className="p-3 rounded-full bg-emerald-100 dark:bg-emerald-900 mr-4">
+                    <Icon className="h-6 w-6 text-emerald-600 dark:text-emerald-400" />
+                  </div>
+                  <div>
+                    <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">{section.title}</h2>
+                    <p className="text-gray-600 dark:text-gray-300 leading-relaxed">{section.content}</p>
+                  </div>
+                </div>
+              </section>
+            );
+          })}
+        </div>
+
+        <section className="mt-16 bg-white/80 dark:bg-gray-900/80 rounded-2xl shadow-lg p-8">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">Data Subject Rights</h2>
+          <p className="text-gray-600 dark:text-gray-300 mb-4">
+            Because SecureCheck does not store personal data, there is no account to delete or export. If you contact us, we
+            store your email solely to respond to the enquiry. You may request deletion at any time by replying to our email or
+            writing to privacy@securecheck.app.
+          </p>
+          <p className="text-gray-600 dark:text-gray-300">
+            We periodically review this policy and will timestamp any material changes. Continued use of SecureCheck after
+            updates constitutes acceptance of the revised terms.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/security-blog.tsx
+++ b/client/src/pages/security-blog.tsx
@@ -1,0 +1,190 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, PenSquare, TrendingUp, AlarmClock, GraduationCap, ArrowRight } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+
+export default function SecurityBlog() {
+  useEffect(() => {
+    document.title = 'SecureCheck Security Blog | Password Intelligence';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Read expert analysis on password security, breach trends, and compliance insights from the SecureCheck research team.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'SecureCheck Security Blog | Password Intelligence');
+    addMetaTag('og:description', 'Insights on password breaches, compliance frameworks, and authentication UX.');
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const featuredPosts = [
+    {
+      title: 'Why Password Length Matters More Than Complexity',
+      summary: 'We analyse 10+ billion leaked credentials to show why length-first policies slash account takeover risk.',
+      category: 'Research',
+      readTime: '8 min read'
+    },
+    {
+      title: 'Designing Password Policies for a Remote Workforce',
+      summary: 'See how distributed teams can adopt passphrases, MFA, and secure recovery flows without harming productivity.',
+      category: 'Strategy',
+      readTime: '6 min read'
+    },
+    {
+      title: 'A Practical Checklist for Annual Compliance Audits',
+      summary: 'Use our evidence templates to prove ongoing password hygiene across NIST, ISO 27001, and PCI DSS scopes.',
+      category: 'Compliance',
+      readTime: '7 min read'
+    }
+  ];
+
+  const newsletterHighlights = [
+    {
+      title: 'Monthly breach landscape briefing',
+      description: 'Top credential exposures summarised with recommended rotations and customer messaging scripts.'
+    },
+    {
+      title: 'Product release spotlights',
+      description: 'Discover new SecureCheck features that automate reporting, export evidence, and simplify collaboration.'
+    },
+    {
+      title: 'Compliance playbooks',
+      description: 'Step-by-step actions for meeting regulator expectations with minimal admin overhead.'
+    }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 dark:from-slate-900 dark:to-orange-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-orange-600 dark:text-orange-400">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-orange-100 dark:bg-orange-900 rounded-full">
+              <PenSquare className="h-12 w-12 text-orange-600 dark:text-orange-400" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">SecureCheck Security Blog</h1>
+          <p className="text-lg md:text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            Curated research, playbooks, and tactics from our password security specialists. Subscribe for monthly insights that
+            help you stay ahead of attackers and compliance demands.
+          </p>
+        </div>
+
+        <section className="mb-16">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-8 text-center">Featured Insights</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {featuredPosts.map((post) => (
+              <Card key={post.title} className="border-0 shadow-lg bg-white/90 dark:bg-gray-900/80 flex flex-col">
+                <CardHeader>
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>{post.category}</span>
+                    <span>{post.readTime}</span>
+                  </div>
+                  <CardTitle className="text-xl">{post.title}</CardTitle>
+                  <CardDescription className="text-base text-gray-600 dark:text-gray-300">
+                    {post.summary}
+                  </CardDescription>
+                </CardHeader>
+                <CardFooter className="mt-auto">
+                  <Button variant="link" className="px-0 text-orange-600 dark:text-orange-400">
+                    Read insight
+                    <ArrowRight className="h-4 w-4 ml-2" />
+                  </Button>
+                </CardFooter>
+              </Card>
+            ))}
+          </div>
+        </section>
+
+        <section className="bg-white dark:bg-gray-900 rounded-2xl shadow-xl p-8 mb-16">
+          <div className="grid md:grid-cols-2 gap-8 items-center">
+            <div>
+              <h2 className="text-3xl font-semibold text-gray-900 dark:text-white mb-4">Join the Newsletter</h2>
+              <p className="text-gray-600 dark:text-gray-300 mb-6">
+                Get one thoughtfully crafted email per month from the SecureCheck research desk. No spam, no fluff—just the
+                actionable intelligence you need for the next board update or audit.
+              </p>
+              <Button className="bg-orange-600 hover:bg-orange-700 text-white">Subscribe</Button>
+            </div>
+            <div className="space-y-4">
+              {newsletterHighlights.map((item) => (
+                <div key={item.title} className="flex items-start">
+                  <GraduationCap className="h-6 w-6 text-orange-500 mt-1 mr-3" />
+                  <div>
+                    <h3 className="text-lg font-semibold text-gray-900 dark:text-white">{item.title}</h3>
+                    <p className="text-gray-600 dark:text-gray-300">{item.description}</p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="bg-white/80 dark:bg-gray-900/80 rounded-2xl shadow-lg p-8">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">On Our Radar</h2>
+          <p className="text-gray-600 dark:text-gray-300 mb-6">
+            We constantly monitor password cracking advancements, regulatory updates, and authentication UX trends. Here are the
+            themes we are preparing deep dives on for upcoming posts.
+          </p>
+          <div className="grid md:grid-cols-3 gap-6">
+            <div className="p-6 rounded-xl bg-orange-50 dark:bg-orange-950/60 border border-orange-100 dark:border-orange-800">
+              <TrendingUp className="h-6 w-6 text-orange-600 dark:text-orange-400 mb-4" />
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Credential Stuffing Economics</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                Analysing how low-cost botnets monetise breached credentials—and what a resilient password policy costs in
+                comparison.
+              </p>
+            </div>
+            <div className="p-6 rounded-xl bg-orange-50 dark:bg-orange-950/60 border border-orange-100 dark:border-orange-800">
+              <AlarmClock className="h-6 w-6 text-orange-600 dark:text-orange-400 mb-4" />
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Adaptive Authentication Timelines</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                Recommendations on when to escalate step-up MFA based on session risk signals and user behaviour analytics.
+              </p>
+            </div>
+            <div className="p-6 rounded-xl bg-orange-50 dark:bg-orange-950/60 border border-orange-100 dark:border-orange-800">
+              <PenSquare className="h-6 w-6 text-orange-600 dark:text-orange-400 mb-4" />
+              <h3 className="font-semibold text-gray-900 dark:text-white mb-2">Human-centred Security Education</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-300">
+                How to deliver memorable training content that helps employees build better passwords without fatigue.
+              </p>
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/terms-of-service.tsx
+++ b/client/src/pages/terms-of-service.tsx
@@ -1,0 +1,127 @@
+import { useEffect } from 'react';
+import { Link } from 'wouter';
+import { Shield, Scale, LifeBuoy } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
+
+export default function TermsOfService() {
+  useEffect(() => {
+    document.title = 'SecureCheck Terms of Service';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Review the terms of service for SecureCheck, including acceptable use, availability, and support commitments.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'SecureCheck Terms of Service');
+    addMetaTag('og:description', 'Understand acceptable use, uptime, warranty disclaimers, and support for SecureCheck.');
+    addMetaTag('og:type', 'website');
+  }, []);
+
+  const clauses = [
+    {
+      title: 'Service Description',
+      content:
+        'SecureCheck provides browser-based password analysis. The service is delivered on an as-is basis and may evolve as we release new features.'
+    },
+    {
+      title: 'Acceptable Use',
+      content:
+        'You agree not to use SecureCheck for unlawful activity or to process credentials you are not authorised to audit.'
+    },
+    {
+      title: 'Availability',
+      content:
+        'We aim for high availability but do not guarantee uninterrupted access. Planned maintenance will be communicated via release notes.'
+    },
+    {
+      title: 'Warranty Disclaimer',
+      content:
+        'SecureCheck disclaims all implied warranties, including fitness for a particular purpose. Use of the tool is at your own risk.'
+    },
+    {
+      title: 'Limitation of Liability',
+      content:
+        'To the extent permitted by law, SecureCheck shall not be liable for indirect, incidental, or consequential damages arising from use of the service.'
+    },
+    {
+      title: 'Governing Law',
+      content:
+        'These terms are governed by the laws of your jurisdiction unless superseded by mandatory local regulations.'
+    }
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-50 to-slate-100 dark:from-slate-900 dark:to-slate-950">
+      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <Link href="/" className="flex items-center space-x-2 text-slate-700 dark:text-slate-300">
+              <Shield className="h-8 w-8" />
+              <span className="text-xl font-bold">SecureCheck</span>
+            </Link>
+            <div className="flex items-center space-x-4">
+              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                100% Private
+              </Badge>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div className="text-center mb-16">
+          <div className="flex justify-center mb-6">
+            <div className="p-3 bg-slate-200 dark:bg-slate-800 rounded-full">
+              <Scale className="h-12 w-12 text-slate-700 dark:text-slate-300" />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold text-gray-900 dark:text-white mb-6">Terms of Service</h1>
+          <p className="text-lg text-gray-600 dark:text-gray-300 max-w-3xl mx-auto">
+            These terms outline your rights and responsibilities when using SecureCheck. Please read them carefully before
+            relying on the service for security or compliance workflows.
+          </p>
+        </div>
+
+        <div className="space-y-10">
+          {clauses.map((clause) => (
+            <section key={clause.title} className="bg-white/90 dark:bg-gray-900/80 rounded-2xl shadow-lg p-8">
+              <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-3">{clause.title}</h2>
+              <p className="text-gray-600 dark:text-gray-300 leading-relaxed">{clause.content}</p>
+            </section>
+          ))}
+        </div>
+
+        <section className="mt-16 bg-white/80 dark:bg-gray-900/80 rounded-2xl shadow-lg p-8">
+          <h2 className="text-2xl font-semibold text-gray-900 dark:text-white mb-4">Support & Contact</h2>
+          <p className="text-gray-600 dark:text-gray-300 mb-4">
+            If you have questions about these terms, please reach out. We aim to respond within two business days and will do our
+            best to resolve any concerns.
+          </p>
+          <div className="flex items-start space-x-3 text-gray-600 dark:text-gray-300">
+            <LifeBuoy className="h-6 w-6 text-slate-600 dark:text-slate-300 mt-1" />
+            <span>
+              Email <a href="mailto:legal@securecheck.app" className="text-slate-700 dark:text-slate-200 underline">legal@securecheck.app</a>{' '}
+              or write to our compliance team for clarification and change requests.
+            </span>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add router entries and footer links for each marketing page mentioned in the homepage footer
- create resource-focused pages covering password best practices, compliance guides, and security insights
- add how-it-works, privacy policy, terms, and contact pages with detailed copy and a contact form

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d67786cf488323b1d23814eebcb03b