### PR TITLE
refactor: unify site header across pages

### DIFF
--- a/client/src/components/site-header.tsx
+++ b/client/src/components/site-header.tsx
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react';
+import { Link } from 'wouter';
+import { Shield } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+
+interface SiteHeaderProps {
+  className?: string;
+  additionalBadges?: ReactNode;
+}
+
+export function SiteHeader({ className, additionalBadges }: SiteHeaderProps) {
+  return (
+    <nav className={cn('bg-white dark:bg-gray-900 shadow-sm border-b', className)}>
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center h-16">
+          <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
+            <Shield className="h-8 w-8" />
+            <span className="text-xl font-bold" data-testid="app-title">
+              Pw Check
+            </span>
+          </Link>
+          <div className="flex items-center space-x-4">
+            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200" data-testid="privacy-badge">
+              100% Private
+            </Badge>
+            {additionalBadges}
+          </div>
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export default SiteHeader;

--- a/client/src/pages/compliance-comparison.tsx
+++ b/client/src/pages/compliance-comparison.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from 'react';
 import { Link } from 'wouter';
-import { Shield, CheckCircle, XCircle, Info, ArrowRight, GitCompare, Filter } from 'lucide-react';
+import { CheckCircle, XCircle, Info, ArrowRight, GitCompare, Filter } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { SiteHeader } from '@/components/site-header';
 
 export default function ComplianceComparison() {
   const [selectedStandards, setSelectedStandards] = useState<string[]>(['NIST', 'GDPR', 'ISO27001', 'PCI-DSS']);
@@ -135,21 +136,7 @@ export default function ComplianceComparison() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-blue-100 dark:from-gray-900 dark:to-gray-800">
       {/* Navigation */}
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Hero Section */}

--- a/client/src/pages/compliance-guides.tsx
+++ b/client/src/pages/compliance-guides.tsx
@@ -1,8 +1,8 @@
 import { useEffect } from 'react';
-import { Link } from 'wouter';
-import { Shield, BookOpen, Layers, Target, ClipboardCheck, Clock3 } from 'lucide-react';
+import { BookOpen, Layers, Target, ClipboardCheck, Clock3 } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { SiteHeader } from '@/components/site-header';
 
 export default function ComplianceGuides() {
   useEffect(() => {
@@ -96,21 +96,7 @@ export default function ComplianceGuides() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-purple-100 dark:from-gray-900 dark:to-purple-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-purple-600 dark:text-purple-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">

--- a/client/src/pages/contact.tsx
+++ b/client/src/pages/contact.tsx
@@ -1,11 +1,10 @@
 import { useEffect } from 'react';
-import { Link } from 'wouter';
-import { Shield, Mail, PhoneCall, MessageSquare, MapPin, Send } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { Mail, PhoneCall, MessageSquare, MapPin, Send } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Input } from '@/components/ui/input';
+import { SiteHeader } from '@/components/site-header';
 
 export default function Contact() {
   useEffect(() => {
@@ -63,21 +62,7 @@ export default function Contact() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-sky-50 to-indigo-100 dark:from-slate-900 dark:to-indigo-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-indigo-600 dark:text-indigo-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">

--- a/client/src/pages/gdpr-password-compliance.tsx
+++ b/client/src/pages/gdpr-password-compliance.tsx
@@ -4,6 +4,7 @@ import { Shield, CheckCircle, Users, ArrowRight, Lock, Euro } from 'lucide-react
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { SiteHeader } from '@/components/site-header';
 
 export default function GDPRPasswordCompliance() {
   useEffect(() => {
@@ -80,25 +81,14 @@ export default function GDPRPasswordCompliance() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-100 dark:from-gray-900 dark:to-gray-800">
       {/* Navigation */}
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-              <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
-                <Euro className="h-3 w-3 mr-1" />
-                EU Compliant
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader
+        additionalBadges={
+          <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
+            <Euro className="h-3 w-3 mr-1" />
+            EU Compliant
+          </Badge>
+        }
+      />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Hero Section */}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -6,33 +6,12 @@ import { PasswordGenerator } from '@/components/password-generator';
 import { PrivacyNotice } from '@/components/privacy-notice';
 import { SecurityTips } from '@/components/security-tips';
 import { MethodologySection } from '@/components/methodology-section';
+import { SiteHeader } from '@/components/site-header';
 
 export default function Home() {
   return (
-    <div className="min-h-screen bg-background text-foreground">
-      {/* Header */}
-      <header className="border-b border-border bg-card">
-        <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <div className="flex items-center justify-between">
-            <div className="flex items-center space-x-3">
-              <div className="w-8 h-8 bg-primary rounded-lg flex items-center justify-center">
-                <Lock className="w-5 h-5 text-primary-foreground" />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold" data-testid="app-title">SecureCheck</h1>
-                <p className="text-sm text-muted-foreground">Professional Password Analyzer</p>
-              </div>
-            </div>
-            
-            <div className="flex items-center space-x-2 bg-muted px-3 py-2 rounded-lg">
-              <CheckCircle className="w-4 h-4 text-success" />
-              <span className="text-sm font-medium" data-testid="privacy-badge">
-                100% Private - No Data Leaves Your Browser
-              </span>
-            </div>
-          </div>
-        </div>
-      </header>
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800 text-foreground">
+      <SiteHeader />
 
       {/* Hero Section */}
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/client/src/pages/how-it-works.tsx
+++ b/client/src/pages/how-it-works.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 import { Link } from 'wouter';
-import { Shield, Workflow, Lock, Gauge, ScrollText, Users, ArrowRight } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { Workflow, Lock, Gauge, ScrollText, Users, ArrowRight } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { SiteHeader } from '@/components/site-header';
 
 export default function HowItWorks() {
   useEffect(() => {
@@ -62,21 +62,7 @@ export default function HowItWorks() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-cyan-100 dark:from-slate-900 dark:to-cyan-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-cyan-600 dark:text-cyan-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">

--- a/client/src/pages/iso27001-password-rules.tsx
+++ b/client/src/pages/iso27001-password-rules.tsx
@@ -4,6 +4,7 @@ import { Shield, CheckCircle, Building, ArrowRight, Lock, Globe } from 'lucide-r
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { SiteHeader } from '@/components/site-header';
 
 export default function ISO27001PasswordRules() {
   useEffect(() => {
@@ -104,25 +105,14 @@ export default function ISO27001PasswordRules() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-100 dark:from-gray-900 dark:to-gray-800">
       {/* Navigation */}
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-              <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
-                <Globe className="h-3 w-3 mr-1" />
-                ISO Certified
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader
+        additionalBadges={
+          <Badge variant="outline" className="bg-blue-50 text-blue-700 border-blue-200">
+            <Globe className="h-3 w-3 mr-1" />
+            ISO Certified
+          </Badge>
+        }
+      />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Hero Section */}

--- a/client/src/pages/nist-password-checker.tsx
+++ b/client/src/pages/nist-password-checker.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from 'react';
 import { Link } from 'wouter';
-import { Shield, CheckCircle, AlertTriangle, ArrowRight, Lock } from 'lucide-react';
+import { CheckCircle, AlertTriangle, ArrowRight, Lock } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { Badge } from '@/components/ui/badge';
+import { SiteHeader } from '@/components/site-header';
 
 export default function NISTPasswordChecker() {
   useEffect(() => {
@@ -72,21 +72,7 @@ export default function NISTPasswordChecker() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-gray-900 dark:to-gray-800">
       {/* Navigation */}
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Hero Section */}

--- a/client/src/pages/password-best-practices.tsx
+++ b/client/src/pages/password-best-practices.tsx
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
-import { Link } from 'wouter';
-import { Shield, CheckCircle, ListChecks, Lock, AlertTriangle, Sparkles } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { CheckCircle, ListChecks, Lock, AlertTriangle, Sparkles } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { SiteHeader } from '@/components/site-header';
 
 export default function PasswordBestPractices() {
   useEffect(() => {
@@ -72,21 +71,7 @@ export default function PasswordBestPractices() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-blue-100 dark:from-slate-900 dark:to-blue-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">

--- a/client/src/pages/pci-dss-password-requirements.tsx
+++ b/client/src/pages/pci-dss-password-requirements.tsx
@@ -4,6 +4,7 @@ import { Shield, CheckCircle, CreditCard, ArrowRight, Lock, DollarSign } from 'l
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { SiteHeader } from '@/components/site-header';
 
 export default function PCIDSSPasswordRequirements() {
   useEffect(() => {
@@ -116,25 +117,14 @@ export default function PCIDSSPasswordRequirements() {
   return (
     <div className="min-h-screen bg-gradient-to-br from-red-50 to-blue-100 dark:from-gray-900 dark:to-gray-800">
       {/* Navigation */}
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-blue-600 dark:text-blue-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-              <Badge variant="outline" className="bg-red-50 text-red-700 border-red-200">
-                <DollarSign className="h-3 w-3 mr-1" />
-                PCI Certified
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader
+        additionalBadges={
+          <Badge variant="outline" className="bg-red-50 text-red-700 border-red-200">
+            <DollarSign className="h-3 w-3 mr-1" />
+            PCI Certified
+          </Badge>
+        }
+      />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         {/* Hero Section */}

--- a/client/src/pages/privacy-policy.tsx
+++ b/client/src/pages/privacy-policy.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
-import { Link } from 'wouter';
 import { Shield, LockKeyhole, EyeOff, Server, FileCheck2 } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { SiteHeader } from '@/components/site-header';
 
 export default function PrivacyPolicy() {
   useEffect(() => {
@@ -62,21 +61,7 @@ export default function PrivacyPolicy() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-emerald-100 dark:from-slate-900 dark:to-emerald-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-emerald-600 dark:text-emerald-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">

--- a/client/src/pages/security-blog.tsx
+++ b/client/src/pages/security-blog.tsx
@@ -1,9 +1,8 @@
 import { useEffect } from 'react';
-import { Link } from 'wouter';
 import { Shield, PenSquare, TrendingUp, AlarmClock, GraduationCap, ArrowRight } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { SiteHeader } from '@/components/site-header';
 
 export default function SecurityBlog() {
   useEffect(() => {
@@ -73,21 +72,7 @@ export default function SecurityBlog() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 dark:from-slate-900 dark:to-orange-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-orange-600 dark:text-orange-400">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">

--- a/client/src/pages/terms-of-service.tsx
+++ b/client/src/pages/terms-of-service.tsx
@@ -1,7 +1,6 @@
 import { useEffect } from 'react';
-import { Link } from 'wouter';
 import { Shield, Scale, LifeBuoy } from 'lucide-react';
-import { Badge } from '@/components/ui/badge';
+import { SiteHeader } from '@/components/site-header';
 
 export default function TermsOfService() {
   useEffect(() => {
@@ -68,21 +67,7 @@ export default function TermsOfService() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-50 to-slate-100 dark:from-slate-900 dark:to-slate-950">
-      <nav className="bg-white dark:bg-gray-900 shadow-sm border-b">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="flex justify-between items-center h-16">
-            <Link href="/" className="flex items-center space-x-2 text-slate-700 dark:text-slate-300">
-              <Shield className="h-8 w-8" />
-              <span className="text-xl font-bold">Pw Check</span>
-            </Link>
-            <div className="flex items-center space-x-4">
-              <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
-                100% Private
-              </Badge>
-            </div>
-          </div>
-        </div>
-      </nav>
+      <SiteHeader />
 
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
         <div className="text-center mb-16">


### PR DESCRIPTION
## Summary
- add a reusable SiteHeader component so the logo and privacy badge stay consistent everywhere
- replace duplicated page-specific navigation markup with the shared header across the home and marketing pages
- refresh the home page background treatment to better match the marketing gradient styling

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68d7c6cb24008323b0f7be7ddb6d8ff3