### PR TITLE
Add dedicated pages for security tips

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -17,6 +17,9 @@ import HowItWorks from "@/pages/how-it-works";
 import PrivacyPolicy from "@/pages/privacy-policy";
 import TermsOfService from "@/pages/terms-of-service";
 import Contact from "@/pages/contact";
+import UsePasswordManager from "@/pages/security/use-password-manager";
+import EnableTwoFactorAuthentication from "@/pages/security/enable-two-factor-authentication";
+import AvoidPasswordReuse from "@/pages/security/avoid-password-reuse";
 
 function Router() {
   return (
@@ -30,6 +33,12 @@ function Router() {
       <Route path="/password-best-practices" component={PasswordBestPractices} />
       <Route path="/compliance-guides" component={ComplianceGuides} />
       <Route path="/security-blog" component={SecurityBlog} />
+      <Route path="/security/use-password-manager" component={UsePasswordManager} />
+      <Route
+        path="/security/enable-two-factor-authentication"
+        component={EnableTwoFactorAuthentication}
+      />
+      <Route path="/security/avoid-password-reuse" component={AvoidPasswordReuse} />
       <Route path="/how-it-works" component={HowItWorks} />
       <Route path="/privacy-policy" component={PrivacyPolicy} />
       <Route path="/terms-of-service" component={TermsOfService} />

--- a/client/src/components/security-tips.tsx
+++ b/client/src/components/security-tips.tsx
@@ -1,21 +1,28 @@
 import { Card } from '@/components/ui/card';
+import { Link } from 'wouter';
 
 export function SecurityTips() {
   const tips = [
     {
       title: 'Use a Password Manager',
       description: 'Generate and store unique passwords for every account',
-      tooltip: 'Click to learn more about password managers'
+      tooltip: 'Click to learn more about password managers',
+      href: '/security/use-password-manager',
+      testId: 'security-tip-password-manager'
     },
     {
       title: 'Enable 2FA',
       description: 'Add an extra layer of security to your accounts',
-      tooltip: 'Learn about two-factor authentication'
+      tooltip: 'Learn about two-factor authentication',
+      href: '/security/enable-two-factor-authentication',
+      testId: 'security-tip-2fa'
     },
     {
       title: 'Avoid Password Reuse',
       description: 'Never use the same password across multiple sites',
-      tooltip: 'Understand password reuse risks'
+      tooltip: 'Understand password reuse risks',
+      href: '/security/avoid-password-reuse',
+      testId: 'security-tip-reuse'
     }
   ];
 
@@ -24,15 +31,18 @@ export function SecurityTips() {
       <h3 className="text-lg font-semibold mb-4">Security Tips</h3>
       <div className="space-y-3">
         {tips.map((tip, index) => (
-          <div
+          <Link
             key={index}
-            className="p-3 bg-muted rounded-lg cursor-pointer hover:bg-accent transition-colors"
+            href={tip.href}
+            className="block"
             title={tip.tooltip}
-            data-testid={`security-tip-${index}`}
+            data-testid={tip.testId}
           >
-            <h4 className="font-medium text-sm">{tip.title}</h4>
-            <p className="text-xs text-muted-foreground">{tip.description}</p>
-          </div>
+            <Card className="p-3 bg-muted hover:bg-accent transition-colors border-none shadow-none">
+              <h4 className="font-medium text-sm text-foreground">{tip.title}</h4>
+              <p className="text-xs text-muted-foreground">{tip.description}</p>
+            </Card>
+          </Link>
         ))}
       </div>
     </div>

--- a/client/src/pages/security/avoid-password-reuse.tsx
+++ b/client/src/pages/security/avoid-password-reuse.tsx
@@ -1,0 +1,154 @@
+import { useEffect } from 'react';
+import { AlertTriangle, RefreshCcw, ShieldX, Database, ClipboardCheck } from 'lucide-react';
+import { SiteHeader } from '@/components/site-header';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function AvoidPasswordReuse() {
+  useEffect(() => {
+    document.title = 'Avoid Password Reuse | Pw Check';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Discover why password reuse creates systemic risk, how to detect it, and the controls that keep credentials unique.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'Avoid Password Reuse | Pw Check');
+    addMetaTag(
+      'og:description',
+      'Stop credential stuffing by enforcing unique passwords, monitoring for reuse, and guiding teams with practical policies.'
+    );
+    addMetaTag('og:type', 'article');
+  }, []);
+
+  const risks = [
+    {
+      title: 'Breach Cascade',
+      description: 'Compromised credentials from one service can unlock internal systems if staff reuse the same password.',
+      icon: AlertTriangle
+    },
+    {
+      title: 'Invisible Shadow IT',
+      description: 'Untracked accounts using work emails and reused passwords weaken vendor risk and audit readiness.',
+      icon: ShieldX
+    },
+    {
+      title: 'Compliance Findings',
+      description: 'Frameworks such as ISO 27001 and PCI DSS expect controls preventing reuse, especially for privileged access.',
+      icon: Database
+    }
+  ];
+
+  const controls = [
+    'Require password managers for storing and generating credentials across the organisation.',
+    'Automate breach monitoring with services that flag when corporate email addresses appear in credential dumps.',
+    'Review directory logs to identify simultaneous logins with outdated or shared credentials.',
+    'Implement conditional access policies that block known reused passwords via password filters or SSO rules.'
+  ];
+
+  const changeManagement = [
+    'Explain the business impact of password reuse with real incident examples relevant to each department.',
+    'Provide migration guides that show how to replace reused passwords with unique passphrases stored in managed vaults.',
+    'Run quarterly health checks using Pw Check to verify no reused credentials remain in high-value systems.',
+    'Celebrate teams that achieve zero-reuse status and share their processes in internal knowledge bases.'
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-rose-50 to-red-100 dark:from-slate-950 dark:to-rose-950 text-foreground">
+      <SiteHeader />
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-16">
+        <section className="text-center space-y-6">
+          <div className="flex justify-center">
+            <div className="p-4 rounded-full bg-rose-100 dark:bg-rose-900">
+              <RefreshCcw className="h-12 w-12 text-rose-600 dark:text-rose-300" aria-hidden />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold">Break the Password Reuse Habit</h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
+            Password reuse gives attackers a head start. Replace repeated credentials with unique passphrases that align with
+            your compliance framework and reduce the blast radius of any breach.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-center mb-8">Why Reuse Is Dangerous</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {risks.map((risk) => {
+              const Icon = risk.icon;
+              return (
+                <Card key={risk.title} className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+                  <CardHeader className="text-center space-y-4">
+                    <div className="flex justify-center">
+                      <div className="p-3 rounded-full bg-rose-100 dark:bg-rose-900">
+                        <Icon className="h-8 w-8 text-rose-600 dark:text-rose-300" aria-hidden />
+                      </div>
+                    </div>
+                    <CardTitle className="text-xl">{risk.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-base text-muted-foreground text-center">
+                      {risk.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <Card className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center text-xl">
+                <ClipboardCheck className="h-5 w-5 text-rose-500 mr-3" aria-hidden />
+                Preventative Controls
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4 text-muted-foreground">
+                {controls.map((control) => (
+                  <li key={control} className="flex items-start">
+                    <span className="mt-1 mr-3 inline-flex h-2 w-2 rounded-full bg-rose-500" aria-hidden />
+                    <span>{control}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center text-xl">
+                <AlertTriangle className="h-5 w-5 text-amber-500 mr-3" aria-hidden />
+                Change Management Tips
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ol className="list-decimal list-inside space-y-3 text-muted-foreground">
+                {changeManagement.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/security/enable-two-factor-authentication.tsx
+++ b/client/src/pages/security/enable-two-factor-authentication.tsx
@@ -1,0 +1,153 @@
+import { useEffect } from 'react';
+import { ShieldAlert, Smartphone, QrCode, KeySquare, BellRing } from 'lucide-react';
+import { SiteHeader } from '@/components/site-header';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function EnableTwoFactorAuthentication() {
+  useEffect(() => {
+    document.title = 'Enable Two-Factor Authentication | Pw Check';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Understand the value of two-factor authentication, the options available, and how to deploy MFA for your organisation.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'Enable Two-Factor Authentication | Pw Check');
+    addMetaTag(
+      'og:description',
+      'Learn the difference between SMS, authenticator apps, and passkeys while building a rollout plan that increases adoption.'
+    );
+    addMetaTag('og:type', 'article');
+  }, []);
+
+  const factors = [
+    {
+      title: 'Authenticator Apps',
+      description: 'Time-based one-time codes generated on trusted devices. Works offline and integrates with most identity providers.',
+      icon: Smartphone
+    },
+    {
+      title: 'Hardware Security Keys',
+      description: 'FIDO2/WebAuthn compliant keys resist phishing and can enforce strong authentication for admins and developers.',
+      icon: KeySquare
+    },
+    {
+      title: 'Push Notifications',
+      description: 'Modern push-based MFA delivers tap-to-approve experiences with device intelligence for risk-based policies.',
+      icon: BellRing
+    }
+  ];
+
+  const deploymentSteps = [
+    'Prioritise privileged and high-risk applications, ensuring identity provider policies require MFA at every login.',
+    'Offer at least two MFA options to balance usability and accessibility needs, including hardware keys for critical roles.',
+    'Educate staff on phishing-resistant prompts and how to report suspicious MFA requests immediately.',
+    'Track enrollment metrics in the first 30 days and send targeted nudges to teams lagging behind.'
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 dark:from-slate-950 dark:to-indigo-950 text-foreground">
+      <SiteHeader />
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-16">
+        <section className="text-center space-y-6">
+          <div className="flex justify-center">
+            <div className="p-4 rounded-full bg-indigo-100 dark:bg-indigo-900">
+              <ShieldAlert className="h-12 w-12 text-indigo-600 dark:text-indigo-300" aria-hidden />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold">Enable Two-Factor Authentication Everywhere</h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
+            Two-factor authentication blocks the majority of credential stuffing and phishing attacks. Pair strong passwords with
+            phishing-resistant factors to meet compliance mandates and reduce account takeover risk.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-center mb-8">Common Factor Types</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {factors.map((factor) => {
+              const Icon = factor.icon;
+              return (
+                <Card key={factor.title} className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+                  <CardHeader className="text-center space-y-4">
+                    <div className="flex justify-center">
+                      <div className="p-3 rounded-full bg-indigo-100 dark:bg-indigo-900">
+                        <Icon className="h-8 w-8 text-indigo-600 dark:text-indigo-300" aria-hidden />
+                      </div>
+                    </div>
+                    <CardTitle className="text-xl">{factor.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-base text-muted-foreground text-center">
+                      {factor.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <Card className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center text-xl">
+                <QrCode className="h-5 w-5 text-indigo-500 mr-3" aria-hidden />
+                Enrollment Essentials
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4 text-muted-foreground">
+                <li className="flex items-start">
+                  <span className="mt-1 mr-3 inline-flex h-2 w-2 rounded-full bg-indigo-500" aria-hidden />
+                  <span>Document fallback verification methods and keep recovery codes in a protected vault.</span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mt-1 mr-3 inline-flex h-2 w-2 rounded-full bg-indigo-500" aria-hidden />
+                  <span>Integrate MFA checks into onboarding and offboarding workflows so access is revoked cleanly.</span>
+                </li>
+                <li className="flex items-start">
+                  <span className="mt-1 mr-3 inline-flex h-2 w-2 rounded-full bg-indigo-500" aria-hidden />
+                  <span>Test MFA enforcement on remote access, VPN, and administrative consoles before broad launch.</span>
+                </li>
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center text-xl">
+                <Smartphone className="h-5 w-5 text-green-500 mr-3" aria-hidden />
+                Deployment Roadmap
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ol className="list-decimal list-inside space-y-3 text-muted-foreground">
+                {deploymentSteps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/client/src/pages/security/use-password-manager.tsx
+++ b/client/src/pages/security/use-password-manager.tsx
@@ -1,0 +1,154 @@
+import { useEffect } from 'react';
+import { KeyRound, ShieldCheck, UsersRound, LockKeyhole, ClipboardList } from 'lucide-react';
+import { SiteHeader } from '@/components/site-header';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export default function UsePasswordManager() {
+  useEffect(() => {
+    document.title = 'Password Manager Adoption Guide | Pw Check';
+
+    let metaDescription = document.querySelector('meta[name="description"]');
+    if (!metaDescription) {
+      metaDescription = document.createElement('meta');
+      metaDescription.setAttribute('name', 'description');
+      document.head.appendChild(metaDescription);
+    }
+    metaDescription.setAttribute(
+      'content',
+      'Learn how password managers reduce breaches, how to vet vendors, and how to roll out secure credential sharing for teams.'
+    );
+
+    const addMetaTag = (property: string, content: string) => {
+      let metaTag = document.querySelector(`meta[property="${property}"]`);
+      if (!metaTag) {
+        metaTag = document.createElement('meta');
+        metaTag.setAttribute('property', property);
+        document.head.appendChild(metaTag);
+      }
+      metaTag.setAttribute('content', content);
+    };
+
+    addMetaTag('og:title', 'Password Manager Adoption Guide | Pw Check');
+    addMetaTag(
+      'og:description',
+      'Practical guidance for selecting, securing, and launching a password manager that keeps credentials unique and encrypted.'
+    );
+    addMetaTag('og:type', 'article');
+  }, []);
+
+  const benefits = [
+    {
+      title: 'Unique Credentials Everywhere',
+      description: 'Generate one-of-a-kind passwords with built-in breach monitoring and rotation reminders.',
+      icon: KeyRound
+    },
+    {
+      title: 'Encrypted Storage and Sync',
+      description: 'Modern vaults encrypt locally, sync securely, and give detailed audit trails for compliance.',
+      icon: ShieldCheck
+    },
+    {
+      title: 'Frictionless Collaboration',
+      description: 'Shared vaults and role-based permissions help teams distribute secrets without messaging apps.',
+      icon: UsersRound
+    }
+  ];
+
+  const evaluationCriteria = [
+    'Zero-knowledge architecture with published security audits.',
+    'Granular access controls (role-based access, approval workflows, emergency access).',
+    'Native support for SSO, SCIM provisioning, and hardware-backed MFA.',
+    'Transparent incident response process and clear data residency options.'
+  ];
+
+  const rolloutSteps = [
+    'Pilot the password manager with a small security champion group to gather feedback on usability.',
+    'Import existing credentials from spreadsheets or browsers, flagging reused or weak entries for immediate replacement.',
+    'Enable mandatory MFA for vault access and document recovery processes using secure administrators.',
+    'Run short enablement sessions showing how autofill works on desktop and mobile, highlighting phishing protections.'
+  ];
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-100 dark:from-slate-950 dark:to-amber-950 text-foreground">
+      <SiteHeader />
+
+      <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-12 space-y-16">
+        <section className="text-center space-y-6">
+          <div className="flex justify-center">
+            <div className="p-4 rounded-full bg-orange-100 dark:bg-orange-900">
+              <LockKeyhole className="h-12 w-12 text-orange-600 dark:text-orange-300" aria-hidden />
+            </div>
+          </div>
+          <h1 className="text-4xl md:text-5xl font-bold">Why Your Team Needs a Password Manager</h1>
+          <p className="text-lg md:text-xl text-muted-foreground max-w-3xl mx-auto">
+            Password managers enforce unique, complex credentials without overburdening staff. They align with NIST SP 800-63B
+            guidance and form the foundation of modern credential hygiene programs.
+          </p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold text-center mb-8">Key Security and Productivity Benefits</h2>
+          <div className="grid gap-6 md:grid-cols-3">
+            {benefits.map((benefit) => {
+              const Icon = benefit.icon;
+              return (
+                <Card key={benefit.title} className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+                  <CardHeader className="text-center space-y-4">
+                    <div className="flex justify-center">
+                      <div className="p-3 rounded-full bg-orange-100 dark:bg-orange-900">
+                        <Icon className="h-8 w-8 text-orange-600 dark:text-orange-300" aria-hidden />
+                      </div>
+                    </div>
+                    <CardTitle className="text-xl">{benefit.title}</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    <CardDescription className="text-base text-muted-foreground text-center">
+                      {benefit.description}
+                    </CardDescription>
+                  </CardContent>
+                </Card>
+              );
+            })}
+          </div>
+        </section>
+
+        <section className="grid gap-8 lg:grid-cols-[1.1fr_0.9fr]">
+          <Card className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center text-xl">
+                <ClipboardList className="h-5 w-5 text-orange-500 mr-3" aria-hidden />
+                Vendor Evaluation Checklist
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ul className="space-y-4 text-muted-foreground">
+                {evaluationCriteria.map((item) => (
+                  <li key={item} className="flex items-start">
+                    <span className="mt-1 mr-3 inline-flex h-2 w-2 rounded-full bg-orange-500" aria-hidden />
+                    <span>{item}</span>
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+
+          <Card className="bg-white/90 dark:bg-slate-900/80 border-0 shadow-lg">
+            <CardHeader>
+              <CardTitle className="flex items-center text-xl">
+                <ShieldCheck className="h-5 w-5 text-green-500 mr-3" aria-hidden />
+                Roll-out Playbook
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <ol className="list-decimal list-inside space-y-3 text-muted-foreground">
+                {rolloutSteps.map((step) => (
+                  <li key={step}>{step}</li>
+                ))}
+              </ol>
+            </CardContent>
+          </Card>
+        </section>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add content-rich pages for password manager adoption, enabling two-factor authentication, and avoiding password reuse
- link the security tips sidebar cards to their respective guides using wouter navigation
- register the new routes in the application router and include SEO metadata for each page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d81deaead48323bad0a48e7054627d